### PR TITLE
Implement Create Proposal Instruction

### DIFF
--- a/src/instructions/create_proposal.rs
+++ b/src/instructions/create_proposal.rs
@@ -1,0 +1,53 @@
+use pinocchio::{
+    ProgramResult,
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey,
+    sysvars::{Sysvar, clock::Clock, rent::Rent},
+};
+
+use crate::state::proposal::{ProposalState, ProposalStatus};
+pub fn process_create_proposal_instruction(accounts: &[AccountInfo], data: &[u8]) -> ProgramResult {
+    let [creator, proposal_account, multisig_account, _remaining @ ..] = accounts else {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    };
+
+    let bump = unsafe { *(data.as_ptr() as *const u8) };
+    let bump_bytes = bump.to_le_bytes();
+
+    let seed = [
+        (b"proposal"),
+        multisig_account.key().as_slice(),
+        bump_bytes.as_ref(),
+    ];
+
+    let seeds = &seed[..];
+    let pda = pubkey::checked_create_program_address(seeds, &crate::ID).unwrap();
+
+    assert_eq!(&pda, proposal_account.key());
+
+    if proposal_account.owner() != &crate::ID {
+        pinocchio_system::instructions::CreateAccount {
+            from: creator,
+            to: proposal_account,
+            lamports: Rent::get()?.minimum_balance(ProposalState::LEN),
+            space: ProposalState::LEN as u64,
+            owner: &crate::ID,
+        }
+        .invoke()?;
+    } else {
+        return Err(ProgramError::AccountAlreadyInitialized);
+    }
+
+    let proposal = ProposalState::from_account_info(proposal_account)?;
+
+    proposal.bump = bump;
+    proposal.proposal_id = Clock::get()?.slot;
+    proposal.result = ProposalStatus::Draft;
+    proposal.created_time = Clock::get()?.slot;
+    proposal.expiry = unsafe { *(data.as_ptr().add(16) as *const u64) }; //Extract the u64 value from the instruction data. Here, 16 means we move the pointer forward by 16 bytes, so it now points to the 17th byte in the slice.
+    proposal.active_members = [pubkey::Pubkey::default(); 10];
+    proposal.votes = [0u8; 10]; //10 would be max number of active members
+
+    Ok(())
+}

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -1,21 +1,21 @@
+pub mod create_proposal;
 pub mod init_multisig;
-
+pub use create_proposal::*;
 pub use init_multisig::*;
-
 use pinocchio::program_error::ProgramError;
 
 pub enum MultisigInstructions {
-    InitMultisig = 0, // Johnny + Raunit 
+    InitMultisig = 0, // Johnny + Raunit
     //update expiry
     //update threshold
     //update members
     UpdateMultisig = 1, // Glacier + SOLDADDY + Zubayr + Yunohu
     CreateProposal = 2, // Nishant + Umang
-    Vote = 3, // Shrinath + Mohammed + shradesh
+    Vote = 3,           // Shrinath + Mohammed + shradesh
     // will close if expiry achieved & votes < threshold || execute if votes >= threshold
-    CloseProposal = 4, // Nanasi + Mishal + Apaar + Ghazal 
+    CloseProposal = 4, // Nanasi + Mishal + Apaar + Ghazal
 
-    //Santoshi CHAD own version
+                       //Santoshi CHAD own version
 }
 
 impl TryFrom<&u8> for MultisigInstructions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,12 @@
 extern crate std;
 
 use pinocchio::{
-    account_info::AccountInfo, 
-    entrypoint, 
-    program_error::ProgramError, 
+    ProgramResult, account_info::AccountInfo, entrypoint, program_error::ProgramError,
     pubkey::Pubkey,
-    ProgramResult,
 };
 
-mod state;
 mod instructions;
+mod state;
 
 use instructions::*;
 
@@ -25,19 +22,21 @@ pub fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     data: &[u8],
-
 ) -> ProgramResult {
     assert_eq!(program_id, &ID);
-    
-
 
     let (discriminator, data) = data.split_first().ok_or(ProgramError::InvalidAccountData)?;
 
     match MultisigInstructions::try_from(discriminator)? {
-        MultisigInstructions::InitMultisig => instructions::process_init_multisig_instruction(accounts, data)?,
+        MultisigInstructions::InitMultisig => {
+            instructions::process_init_multisig_instruction(accounts, data)?
+        }
         //MultisigInstructions::UpdateMultisig => instructions::process_init_multisig_instruction(accounts, data)?,
-        //MultisigInstructions::CreateProposal => instructions::process_init_multisig_instruction(accounts, data)?,
+        MultisigInstructions::CreateProposal => {
+            instructions::process_init_multisig_instruction(accounts, data)?
+        }
         //MultisigInstructions::Vote => instructions::process_init_multisig_instruction(accounts, data)?,
+        _ => todo!(),
     }
 
     Ok(())

--- a/src/state/proposal.rs
+++ b/src/state/proposal.rs
@@ -1,20 +1,18 @@
-use pinocchio::{
-    account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey
-};
+use pinocchio::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 
 #[repr(C)]
 pub struct ProposalState {
     pub proposal_id: u64, // Unique identifier for the proposal
-    pub expiry: u64,// Adjust size as needed is it needed here?
+    pub expiry: u64,      // Adjust size as needed is it needed here?
     pub result: ProposalStatus,
-    pub bump: u8, // Bump seed for PDA
+    pub bump: u8,                     // Bump seed for PDA
     pub active_members: [Pubkey; 10], // Array to hold active members, adjust size as needed
 
     //VOTE 0 - NOT VOTED
     //VOTE 1 - FOR
     //VOTE 2 - AGAINST
     //VOTE 3 - ABSTAIN
-    pub votes:[u8; 10],
+    pub votes: [u8; 10],
 
     // imo slot
     pub created_time: u64,
@@ -22,13 +20,15 @@ pub struct ProposalState {
 }
 
 impl ProposalState {
-    pub const LEN: usize = 8 + 8 + 1 + 1 + 32 * 10 + 32 * 10 + 32 * 10 + 8 ; // Adjust size as needed
+    pub const LEN: usize = 8 + 8 + 1 + 1 + 32 * 10 + 32 * 10 + 32 * 10 + 8; // Adjust size as needed
 
-    pub fn from_account_info_unchecked(account_info: &AccountInfo) -> &mut Self {
+    pub fn from_account_info_unchecked(account_info: &mut AccountInfo) -> &mut Self {
         unsafe { &mut *(account_info.borrow_mut_data_unchecked().as_ptr() as *mut Self) }
     }
 
-    pub fn from_account_info(account_info: &AccountInfo) -> Result<&mut Self, pinocchio::program_error::ProgramError> {
+    pub fn from_account_info(
+        account_info: &mut AccountInfo,
+    ) -> Result<&mut Self, pinocchio::program_error::ProgramError> {
         if account_info.data_len() < Self::LEN {
             return Err(pinocchio::program_error::ProgramError::InvalidAccountData);
         }
@@ -43,7 +43,6 @@ pub enum ProposalStatus {
     Succeeded = 3,
     Cancelled = 4,
 }
-
 
 impl TryFrom<&u8> for ProposalStatus {
     type Error = ProgramError;

--- a/src/state/proposal.rs
+++ b/src/state/proposal.rs
@@ -22,12 +22,12 @@ pub struct ProposalState {
 impl ProposalState {
     pub const LEN: usize = 8 + 8 + 1 + 1 + 32 * 10 + 32 * 10 + 32 * 10 + 8; // Adjust size as needed
 
-    pub fn from_account_info_unchecked(account_info: &mut AccountInfo) -> &mut Self {
+    pub fn from_account_info_unchecked(account_info: &AccountInfo) -> &mut Self {
         unsafe { &mut *(account_info.borrow_mut_data_unchecked().as_ptr() as *mut Self) }
     }
 
     pub fn from_account_info(
-        account_info: &mut AccountInfo,
+        account_info: &AccountInfo,
     ) -> Result<&mut Self, pinocchio::program_error::ProgramError> {
         if account_info.data_len() < Self::LEN {
             return Err(pinocchio::program_error::ProgramError::InvalidAccountData);


### PR DESCRIPTION
Closes #4

## Summary

implements the `create_proposal` instruction 

## Changes

- ✅ Added `MultisigInstructions::CreateProposal` variant
- ✅ Added `process_create_proposal_instruction` function under `instructions/create_proposal.rs`
- ✅ Derived proposal PDA using bump and validated it
- ✅ Created proposal account if not already initialized
- ✅ Initialized `ProposalState` with:
  - proposal_id from `Clock::get()?.slot`
  - default `ProposalStatus::Draft`
  - default votes `[0; 10]`
  - default active_members `[Pubkey::default(); 10]`
  - `proposal.expiry = unsafe { *(data.as_ptr().add(16) as *const u64) }; 
  - `created_time = current_slot`
- ✅ Added to `process_instruction` dispatch

## Files added:
- src/instructions/create_proposal.rs 


## Files modified:
- src/instructions/mod.rs (added create_proposal module)
- src/lib.rs (added CreateProposal instruction)


Ready for review 🙌